### PR TITLE
Remove deprecated Bourbon functions.

### DIFF
--- a/generators/app/templates/scss/bourbon-neat/_neat-settings.scss
+++ b/generators/app/templates/scss/bourbon-neat/_neat-settings.scss
@@ -2,7 +2,7 @@
 $em-base: $font-size-base !global;
 
 /* Neat Grid */
-$max-width: em(1170px) !global;
+$max-width: 1170px !global;
 $grid-columns: 12 !global;
 // $visual-grid: true !global;
 

--- a/generators/app/templates/scss/default/_base.scss
+++ b/generators/app/templates/scss/default/_base.scss
@@ -23,12 +23,10 @@ body {
 	line-height: $line-height-base;
 }
 
-<% if (framework == "incBourbonNeat") { %>
-@include selection {
+::selection {
 	background: $color-highlight;
 	text-shadow: none;
 }
-<% } %>
 
 a {
 	color: $link-color;
@@ -128,26 +126,26 @@ h1, h2, h3, h4, h5, h6,
 }
 
 h1, .h1 {
-	font-size: em(36);
+	font-size: 2.25rem;
 }
 h2, .h2 {
-	font-size: em(30);
+	font-size: 1.875rem;
 }
 h3, .h3 {
-	font-size: em(24);
+	font-size: 1.5rem;
 	line-height: 1.2;
 }
 h4, .h4 {
-	font-size: em(18);
+	font-size: 1.125rem;
 	line-height: 1.2;
 }
 h5, .h5 {
-	font-size: em(16);
+	font-size: 1rem;
 	line-height: 1.3;
 	margin-bottom: 0.2em;
 }
 h6, .h6 {
-	font-size: em(14);
+	font-size: 0.875rem;
 	line-height: 1.3;
 	margin-bottom: 0.2em;
 }

--- a/generators/app/templates/scss/default/modules/_forms.scss
+++ b/generators/app/templates/scss/default/modules/_forms.scss
@@ -25,11 +25,9 @@ select {
     background: #fafafa;
     border-radius: 4px;
 
-    <% if (framework == "incBourbonNeat") { %>
-    @include placeholder {
+    ::placeholder {
     	color: #aaa;
     }
-    <% } %>
 
     // IE placeholder class
     &.placeholder {

--- a/test/bourbon.js
+++ b/test/bourbon.js
@@ -37,9 +37,7 @@ describe('surprise:bourbon', function () {
       assert.fileContent(docRoot+'/assets/scss/styles.scss', '@import "neat-settings";');
       assert.fileContent(docRoot+'/assets/scss/styles.scss', '@import "neat";');
       assert.fileContent(docRoot+'/assets/scss/styles.scss', '@import "grid";');
-      assert.fileContent(docRoot+'/assets/scss/_base.scss', '@include selection');
       assert.fileContent(docRoot+'/assets/scss/modules/_forms.scss', '#{$all-text-inputs}');
-      assert.fileContent(docRoot+'/assets/scss/modules/_forms.scss', '@include placeholder');
       assert.fileContent(docRoot+'/assets/scss/modules/_forms.scss', '#{$all-text-inputs-focus}');
       assert.fileContent(docRoot+'/assets/scss/modules/_styleguide.scss', 'Bourbon Neat Style Guide styles');
       assert.file(docRoot+'/assets/scss/_grid.scss');
@@ -93,9 +91,7 @@ describe('surprise:bourbon', function () {
         assert.noFileContent(docRoot+'/assets/scss/styles.scss', '@import "neat-settings";');
         assert.noFileContent(docRoot+'/assets/scss/styles.scss', '@import "neat";');
         assert.noFileContent(docRoot+'/assets/scss/styles.scss', '@import "grid";');
-        assert.noFileContent(docRoot+'/assets/scss/_base.scss', '@include selection');
         assert.noFileContent(docRoot+'/assets/scss/modules/_forms.scss', '#{$all-text-inputs}');
-        assert.noFileContent(docRoot+'/assets/scss/modules/_forms.scss', '@include placeholder');
         assert.noFileContent(docRoot+'/assets/scss/modules/_forms.scss', '#{$all-text-inputs-focus}');
         assert.noFileContent(docRoot+'/assets/scss/modules/_styleguide.scss', 'Bourbon Neat Style Guide styles');
         assert.noFile(docRoot+'/assets/scss/_grid.scss');


### PR DESCRIPTION
This patch removes the use of the deprecated Bourbon em() function and switches to standard ::placeholder and ::selection selectors which autoprefixer will catch.